### PR TITLE
Hotfix blob uploads

### DIFF
--- a/.github/workflows/floodscan-cog-blob.yml
+++ b/.github/workflows/floodscan-cog-blob.yml
@@ -12,8 +12,8 @@ on:
           options:
             - "TRUE"
             - "FALSE"
-      schedule:
-        - cron: '00 23 * * *' # Run every day at 11 pm
+  schedule:
+    - cron: '00 23 * * *' # Run every day at 11 pm
 jobs:
   monitor:
     runs-on: ubuntu-latest

--- a/src/upload_latest_cog.R
+++ b/src/upload_latest_cog.R
@@ -6,11 +6,12 @@ box::use(stringr)
 box::use(logger)
 box::use(AzureStor)
 box::use(glue)
-
+box::use(logger)
 box::use(./utils/blob)
 
 # if dry_run will not upload cogs to azure
 dry_run <- as.logical(Sys.getenv("DRY_RUN", unset = TRUE))
+logger$log_info("Dry run: {dry_run}")
 
 run_date <- Sys.Date()
 run_date_chr <- format(run_date,"%Y%m%d")


### PR DESCRIPTION
there was an indentation error in yaml on schedule that was making the CRON jobs not get triggered. Luckily new function from `fill-gaps` branch will fill in any missing cogs on next run - woo!